### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Found a SwiftUI library or snippet that you think is *awesome*? Fork this reposi
 </details>
 
 ## Tutorials
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 *  [iOS App Dev Training](https://developer.apple.com/tutorials/app-dev-training)
 *  [Creating a macOS App](https://developer.apple.com/tutorials/swiftui/creating-a-macos-app)
 *  [Creating a watchOS App](https://developer.apple.com/tutorials/swiftui/creating-a-watchos-app)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Found a SwiftUI library or snippet that you think is *awesome*? Fork this reposi
 </details>
 
 ## Tutorials
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/mobile-development/swiftui-apps) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 *  [iOS App Dev Training](https://developer.apple.com/tutorials/app-dev-training)
 *  [Creating a macOS App](https://developer.apple.com/tutorials/swiftui/creating-a-macos-app)
 *  [Creating a watchOS App](https://developer.apple.com/tutorials/swiftui/creating-a-watchos-app)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/mobile-development/swiftui-apps) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/mobile-development/swiftui-apps) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.